### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/890/431/765/890431765.geojson
+++ b/data/890/431/765/890431765.geojson
@@ -73,6 +73,9 @@
     },
     "wof:country":"AI",
     "wof:created":1469051912,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3b7c5b65b72d4ac5feb0c0ba32f04fd8",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
         }
     ],
     "wof:id":890431765,
-    "wof:lastmodified":1566584587,
+    "wof:lastmodified":1582326271,
     "wof:name":"East End Village",
     "wof:parent_id":85667755,
     "wof:placetype":"locality",

--- a/data/890/441/875/890441875.geojson
+++ b/data/890/441/875/890441875.geojson
@@ -154,6 +154,9 @@
     },
     "wof:country":"AI",
     "wof:created":1469052340,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5e2b97124707c97800ea05e568ec19b6",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
         }
     ],
     "wof:id":890441875,
-    "wof:lastmodified":1566584587,
+    "wof:lastmodified":1582326271,
     "wof:name":"The Valley",
     "wof:parent_id":85667765,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.