### PR TITLE
ai concordances, placetype local, and more

### DIFF
--- a/data/856/677/21/85667721.geojson
+++ b/data/856/677/21/85667721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000877,
-    "geom:area_square_m":10299460.418089,
+    "geom:area_square_m":10299554.561419,
     "geom:bbox":"-63.113872,18.176174,-63.061334,18.212485",
     "geom:latitude":18.194222,
     "geom:longitude":-63.088232,
@@ -205,8 +205,9 @@
         "hasc:id":"AI.BP",
         "qs_pg:id":135905
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AI",
-    "wof:geomhash":"904df27ec39df2d6b05f989282018b90",
+    "wof:geomhash":"6c0caee4e96089d7b50a4db77288e120",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -223,7 +224,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636496651,
+    "wof:lastmodified":1695884842,
     "wof:name":"Blowing Point",
     "wof:parent_id":85632283,
     "wof:placetype":"region",

--- a/data/856/677/25/85667725.geojson
+++ b/data/856/677/25/85667725.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001102,
-    "geom:area_square_m":12939353.863491,
+    "geom:area_square_m":12939333.132051,
     "geom:bbox":"-63.013522,18.234525,-62.925682,18.297251",
     "geom:latitude":18.269751,
     "geom:longitude":-62.977169,
@@ -199,8 +199,9 @@
         "hasc:id":"AI.EE",
         "qs_pg:id":1318374
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AI",
-    "wof:geomhash":"69e28b5e67e4c89e107b3369e354038a",
+    "wof:geomhash":"8889119036c00bb243d16102aec3db6d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -217,7 +218,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636496652,
+    "wof:lastmodified":1695884842,
     "wof:name":"East End",
     "wof:parent_id":85632283,
     "wof:placetype":"region",

--- a/data/856/677/29/85667729.geojson
+++ b/data/856/677/29/85667729.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000107,
-    "geom:area_square_m":1252239.9368,
+    "geom:area_square_m":1252197.866494,
     "geom:bbox":"-63.072629,18.20276,-63.061308,18.219152",
     "geom:latitude":18.210741,
     "geom:longitude":-63.067064,
@@ -179,8 +179,9 @@
         "hasc:id":"AI.GH",
         "qs_pg:id":352450
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AI",
-    "wof:geomhash":"652192bc773e59f7e8c38bde8bc8d6d0",
+    "wof:geomhash":"be3f2443400073d92cd6da2bf0e84762",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -197,7 +198,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636496651,
+    "wof:lastmodified":1695884842,
     "wof:name":"George Hill",
     "wof:parent_id":85632283,
     "wof:placetype":"region",

--- a/data/856/677/35/85667735.geojson
+++ b/data/856/677/35/85667735.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000065,
-    "geom:area_square_m":763429.397059,
+    "geom:area_square_m":763481.142421,
     "geom:bbox":"-63.007548,18.267336,-62.994523,18.274897",
     "geom:latitude":18.270917,
     "geom:longitude":-63.002068,
@@ -207,8 +207,9 @@
         "hasc:id":"AI.IH",
         "qs_pg:id":1182109
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AI",
-    "wof:geomhash":"0cb9bd22668a987b20e254f59f497ff0",
+    "wof:geomhash":"c650e884e3b5c687ea3f7136307f5adf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -223,7 +224,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636496651,
+    "wof:lastmodified":1695884842,
     "wof:name":"Island Harbour",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/856/677/39/85667739.geojson
+++ b/data/856/677/39/85667739.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000246,
-    "geom:area_square_m":2889887.364156,
+    "geom:area_square_m":2889859.299925,
     "geom:bbox":"-63.077902,18.216271,-63.046972,18.231349",
     "geom:latitude":18.224651,
     "geom:longitude":-63.065449,
@@ -199,8 +199,9 @@
         "hasc:id":"AI.NH",
         "qs_pg:id":1191166
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AI",
-    "wof:geomhash":"f2b3917ba86cf1019933b8e284591cd3",
+    "wof:geomhash":"f6791fcfe765f0c52d4cecf2414cc23b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -217,7 +218,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636496652,
+    "wof:lastmodified":1695884842,
     "wof:name":"North Hill",
     "wof:parent_id":85632283,
     "wof:placetype":"region",

--- a/data/856/677/43/85667743.geojson
+++ b/data/856/677/43/85667743.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0006,
-    "geom:area_square_m":7049118.636156,
+    "geom:area_square_m":7049274.56533,
     "geom:bbox":"-63.061165,18.235441,-63.022282,18.27035",
     "geom:latitude":18.254917,
     "geom:longitude":-63.041029,
@@ -181,8 +181,9 @@
         "hasc:id":"AI.NS",
         "qs_pg:id":1191167
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AI",
-    "wof:geomhash":"8391b5f7c15faf545221e75a144b15f7",
+    "wof:geomhash":"8d6884ceca00d668e47c784d57cd05a0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -199,7 +200,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636496651,
+    "wof:lastmodified":1695884842,
     "wof:name":"North Side",
     "wof:parent_id":85632283,
     "wof:placetype":"region",

--- a/data/856/677/49/85667749.geojson
+++ b/data/856/677/49/85667749.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000098,
-    "geom:area_square_m":1148881.728579,
+    "geom:area_square_m":1148923.131645,
     "geom:bbox":"-63.097239,18.21247,-63.075522,18.225967",
     "geom:latitude":18.217874,
     "geom:longitude":-63.082363,
@@ -208,8 +208,9 @@
         "hasc:id":"AI.SG",
         "qs_pg:id":1191165
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AI",
-    "wof:geomhash":"52ce5443b5a6ef1b8b3bfce792bcb031",
+    "wof:geomhash":"89a68a910a364ec0864341c100ae1671",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -226,7 +227,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636496652,
+    "wof:lastmodified":1695884842,
     "wof:name":"Sandy Ground",
     "wof:parent_id":85632283,
     "wof:placetype":"region",

--- a/data/856/677/55/85667755.geojson
+++ b/data/856/677/55/85667755.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00099,
-    "geom:area_square_m":11627404.427083,
+    "geom:area_square_m":11627604.122154,
     "geom:bbox":"-63.034229,18.215031,-62.994407,18.256186",
     "geom:latitude":18.235189,
     "geom:longitude":-63.013946,
@@ -196,8 +196,9 @@
         "hasc:id":"AI.SH",
         "qs_pg:id":1311242
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AI",
-    "wof:geomhash":"88c8f2d202a12817420fc984f70d9ec8",
+    "wof:geomhash":"e85ea73fbef24ef566157fb186e61821",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -214,7 +215,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636496652,
+    "wof:lastmodified":1695884842,
     "wof:name":"Sandy Hill",
     "wof:parent_id":85632283,
     "wof:placetype":"region",

--- a/data/856/677/59/85667759.geojson
+++ b/data/856/677/59/85667759.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000678,
-    "geom:area_square_m":7968242.221822,
+    "geom:area_square_m":7968303.32265,
     "geom:bbox":"-63.122792,18.183583,-63.061308,18.21955",
     "geom:latitude":18.204801,
     "geom:longitude":-63.100794,
@@ -212,8 +212,9 @@
         "hasc:id":"AI.SO",
         "qs_pg:id":954736
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AI",
-    "wof:geomhash":"68741a44e166dd5748ba7eee2d3a3ff8",
+    "wof:geomhash":"10d1488ae5d3c5d188ea1dd3075ffaeb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -228,7 +229,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636496650,
+    "wof:lastmodified":1695884842,
     "wof:name":"South Hill",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/856/677/61/85667761.geojson
+++ b/data/856/677/61/85667761.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000654,
-    "geom:area_square_m":7676299.008036,
+    "geom:area_square_m":7676247.036374,
     "geom:bbox":"-63.048114,18.232267,-62.995204,18.271969",
     "geom:latitude":18.251307,
     "geom:longitude":-63.024272,
@@ -246,8 +246,9 @@
         "qs_pg:id":1191168,
         "wd:id":"Q7619412"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AI",
-    "wof:geomhash":"cbfac749ef4c41b7005773f193e837cd",
+    "wof:geomhash":"3c674e7d2a04609763f8553d486b4c99",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -264,7 +265,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690849751,
+    "wof:lastmodified":1695884842,
     "wof:name":"Stoney Ground",
     "wof:parent_id":85632283,
     "wof:placetype":"region",

--- a/data/856/677/65/85667765.geojson
+++ b/data/856/677/65/85667765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00053,
-    "geom:area_square_m":6221446.86182,
+    "geom:area_square_m":6221580.97198,
     "geom:bbox":"-63.061388,18.198851,-63.030435,18.227913",
     "geom:latitude":18.215884,
     "geom:longitude":-63.047479,
@@ -246,8 +246,9 @@
         "qs_pg:id":1191169,
         "wd:id":"Q7733473"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AI",
-    "wof:geomhash":"b565e9d4bb0e80bd62bf6b49e0ba0022",
+    "wof:geomhash":"235f9531503cd4f1b356e6ef9e80c8c4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -264,7 +265,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690849751,
+    "wof:lastmodified":1695884842,
     "wof:name":"The Farrington",
     "wof:parent_id":85632283,
     "wof:placetype":"region",

--- a/data/856/677/71/85667771.geojson
+++ b/data/856/677/71/85667771.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000098,
-    "geom:area_square_m":1147179.287829,
+    "geom:area_square_m":1147143.354642,
     "geom:bbox":"-63.046972,18.226718,-63.029298,18.235165",
     "geom:latitude":18.231228,
     "geom:longitude":-63.038416,
@@ -205,8 +205,9 @@
         "hasc:id":"AI.TQ",
         "qs_pg:id":230034
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AI",
-    "wof:geomhash":"f594971c615305d9b192ab1a1a7fa960",
+    "wof:geomhash":"9fba6a0cc88c0ed3274aaf23444369ea",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -223,7 +224,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636496652,
+    "wof:lastmodified":1695884842,
     "wof:name":"The Quarter",
     "wof:parent_id":85632283,
     "wof:placetype":"region",

--- a/data/856/677/75/85667775.geojson
+++ b/data/856/677/75/85667775.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000273,
-    "geom:area_square_m":3208722.48551,
+    "geom:area_square_m":3208795.623903,
     "geom:bbox":"-63.072718,18.226718,-63.044108,18.245784",
     "geom:latitude":18.23462,
     "geom:longitude":-63.057805,
@@ -211,8 +211,9 @@
         "hasc:id":"AI.TV",
         "qs_pg:id":1085958
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AI",
-    "wof:geomhash":"b11ad96300a4623289bbbcb4c8160b17",
+    "wof:geomhash":"3a5f06ec2dcdd360226b2a841bbbfc63",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -229,7 +230,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636496651,
+    "wof:lastmodified":1695884842,
     "wof:name":"The Valley",
     "wof:parent_id":85632283,
     "wof:placetype":"region",

--- a/data/856/677/79/85667779.geojson
+++ b/data/856/677/79/85667779.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000892,
-    "geom:area_square_m":10479475.122992,
+    "geom:area_square_m":10479622.205551,
     "geom:bbox":"-63.167836,18.169094,-63.122599,18.208075",
     "geom:latitude":18.185778,
     "geom:longitude":-63.140022,
@@ -194,8 +194,9 @@
         "hasc:id":"AI.WE",
         "qs_pg:id":135904
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AI",
-    "wof:geomhash":"4dfc9492f90407de99fb5e77d609d7eb",
+    "wof:geomhash":"b8aa076f2eb126b5ccb4bf7a3ed48fe3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -212,7 +213,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636496652,
+    "wof:lastmodified":1695884842,
     "wof:name":"West End",
     "wof:parent_id":85632283,
     "wof:placetype":"region",

--- a/data/856/811/35/85681135.geojson
+++ b/data/856/811/35/85681135.geojson
@@ -67,7 +67,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694493126,
+    "wof:lastmodified":1695884282,
     "wof:name":"Minor islands of Anguilla",
     "wof:parent_id":85632283,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.